### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -4,11 +4,11 @@
 # * Git branch and dirty state (if inside a git repo)
 
 function _git_branch_name
-  echo (command git symbolic-ref HEAD ^/dev/null | sed -e 's|^refs/heads/||')
+  echo (command git symbolic-ref HEAD 2> /dev/null | sed -e 's|^refs/heads/||')
 end
 
 function _git_dirty
-  echo (command git status -s --ignore-submodules=dirty ^/dev/null)
+  echo (command git status -s --ignore-submodules=dirty 2> /dev/null)
 end
 
 function fish_prompt


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618